### PR TITLE
Add overlay color picker

### DIFF
--- a/ArkhamOverlay/ArkhamOverlay.csproj
+++ b/ArkhamOverlay/ArkhamOverlay.csproj
@@ -81,6 +81,21 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="Xceed.Wpf.AvalonDock, Version=4.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.4.0.2\lib\net40\Xceed.Wpf.AvalonDock.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Aero, Version=4.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.4.0.2\lib\net40\Xceed.Wpf.AvalonDock.Themes.Aero.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.Metro, Version=4.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.4.0.2\lib\net40\Xceed.Wpf.AvalonDock.Themes.Metro.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.AvalonDock.Themes.VS2010, Version=4.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.4.0.2\lib\net40\Xceed.Wpf.AvalonDock.Themes.VS2010.dll</HintPath>
+    </Reference>
+    <Reference Include="Xceed.Wpf.Toolkit, Version=4.0.0.0, Culture=neutral, PublicKeyToken=3e4669d2f30244f4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Extended.Wpf.Toolkit.4.0.2\lib\net40\Xceed.Wpf.Toolkit.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="App.xaml">

--- a/ArkhamOverlay/ArkhamOverlay.csproj
+++ b/ArkhamOverlay/ArkhamOverlay.csproj
@@ -158,6 +158,7 @@
       <DependentUpon>MainView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Services\ArkhamDbService.cs" />
+    <Compile Include="Utils\ColorToBrushConverter.cs" />
     <Compile Include="Utils\ImageUtils.cs" />
     <Page Include="Pages\ChooseEncounters\ChooseEncountersView.xaml">
       <SubType>Designer</SubType>

--- a/ArkhamOverlay/Data/Configuration.cs
+++ b/ArkhamOverlay/Data/Configuration.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Windows;
+using System.Windows.Media;
 
 namespace ArkhamOverlay.Data {
     public class Configuration : IConfiguration, INotifyPropertyChanged {
@@ -11,9 +12,19 @@ namespace ArkhamOverlay.Data {
             Packs = new List<Pack>();
         }
 
+        private Color _overlayColor;
         private int _overlayHeight;
         private int _overlayWidth;
         private int _cardHeight;
+
+        public Color OverlayColor {
+            get => _overlayColor;
+            set {
+                _overlayColor = value;
+                OnPropertyChanged(nameof(OverlayColor));
+                OnConfigurationChange();
+            }
+        }
 
         public int OverlayHeight {
             get => _overlayHeight;

--- a/ArkhamOverlay/Pages/Main/MainController.cs
+++ b/ArkhamOverlay/Pages/Main/MainController.cs
@@ -233,5 +233,10 @@ namespace ArkhamOverlay.Pages.Main {
         public void ClearCards() {
             ViewModel.AppData.Game.ClearAllCards();
         }
+
+        [Command]
+        public void ResetOverlayColor() {
+            ViewModel.Configuration.OverlayColor = ConfigurationService.DefaultBackgroundColor;
+        }
     }
 }

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -3,6 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         xmlns:data="clr-namespace:ArkhamOverlay.Pages.Main" 
         d:DataContext="{d:DesignInstance Type=data:MainViewModel}"
         mc:Ignorable="d"
@@ -148,6 +149,8 @@
         <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">
             <Button Command="{Binding ShowOverlay}">Show Overlay</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding ClearCards}">Clear Cards</Button>
+            <TextBlock Margin = "10, 0, 0, 0" Text="Overlay background color:" />
+            <xctk:ColorPicker Name="OverlayColorPicker" SelectedColor="{Binding Configuration.OverlayColor}" />
         </StackPanel>
     </StackPanel>
 </Window>

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -150,7 +150,8 @@
             <Button Command="{Binding ShowOverlay}">Show Overlay</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding ClearCards}">Clear Cards</Button>
             <TextBlock Margin = "10, 0, 0, 0" Text="Overlay background color:" />
-            <xctk:ColorPicker Name="OverlayColorPicker" SelectedColor="{Binding Configuration.OverlayColor}" />
+            <xctk:ColorPicker Margin = "10, 0, 0, 0" Name="OverlayColorPicker" SelectedColor="{Binding Configuration.OverlayColor}" />
+            <Button Margin="10, 0, 0, 0" Command="{Binding ResetOverlayColor}">Reset Overlay Color</Button>
         </StackPanel>
     </StackPanel>
 </Window>

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -152,7 +152,7 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">
-            <TextBlock Margin = "10, 0, 0, 0" Text="Overlay background color:" />
+            <TextBlock Text="Overlay background color:" />
             <xctk:ColorPicker Margin = "10, 0, 0, 0" Name="OverlayColorPicker" SelectedColor="{Binding Configuration.OverlayColor}" />
             <Button Margin="10, 0, 0, 0" Command="{Binding ResetOverlayColor}">Reset Overlay Color</Button>
         </StackPanel>

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -149,6 +149,9 @@
         <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">
             <Button Command="{Binding ShowOverlay}">Show Overlay</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding ClearCards}">Clear Cards</Button>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">
             <TextBlock Margin = "10, 0, 0, 0" Text="Overlay background color:" />
             <xctk:ColorPicker Margin = "10, 0, 0, 0" Name="OverlayColorPicker" SelectedColor="{Binding Configuration.OverlayColor}" />
             <Button Margin="10, 0, 0, 0" Command="{Binding ResetOverlayColor}">Reset Overlay Color</Button>

--- a/ArkhamOverlay/Pages/Overlay/OverlayView.xaml
+++ b/ArkhamOverlay/Pages/Overlay/OverlayView.xaml
@@ -4,33 +4,33 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:overlay="clr-namespace:ArkhamOverlay.Pages.Overlay" 
+        xmlns:utils="clr-namespace:ArkhamOverlay.Utils"
         d:DataContext="{d:DesignInstance Type=overlay:OverlayViewModel}"
         mc:Ignorable="d"
         Title="Arkham Overlay"
         ResizeMode="NoResize"
         SizeToContent="WidthAndHeight"
         Left = "10">
-    <Grid Width="{Binding AppData.Configuration.OverlayWidth}" 
-        Height="{Binding AppData.Configuration.OverlayHeight}" 
-        Background="#00B164">
-        <Grid.Resources>
-            <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BoolToVisibility" />
+        <utils:ColorToBrushConverter x:Key="ColorToBrush" />
 
-            <Style x:Key="CardImage" TargetType="{x:Type Image}" >
-                <Setter Property="Margin" Value="{Binding Margin}" />
-                <Setter Property="Height" Value="{Binding Height}" />
-                <Setter Property="Width" Value="{Binding Width}" />
-                <Setter Property="Clip">
-                    <Setter.Value>
-                        <RectangleGeometry RadiusX="{Binding Radius }"
+        <Style x:Key="CardImage" TargetType="{x:Type Image}" >
+            <Setter Property="Margin" Value="{Binding Margin}" />
+            <Setter Property="Height" Value="{Binding Height}" />
+            <Setter Property="Width" Value="{Binding Width}" />
+            <Setter Property="Clip">
+                <Setter.Value>
+                    <RectangleGeometry RadiusX="{Binding Radius }"
                                            RadiusY="{Binding Radius }"
                                            Rect="{Binding ClipRect }"/>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-        </Grid.Resources>
-
-
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+    <Grid Width="{Binding AppData.Configuration.OverlayWidth}" 
+        Height="{Binding AppData.Configuration.OverlayHeight}" 
+        Background="{Binding Path=AppData.Configuration.OverlayColor, Converter={StaticResource ColorToBrush}}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>

--- a/ArkhamOverlay/Services/ConfigurationService.cs
+++ b/ArkhamOverlay/Services/ConfigurationService.cs
@@ -3,9 +3,11 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
+using System.Windows.Media;
 
 namespace ArkhamOverlay.Services {
     public interface IConfiguration {
+        Color OverlayColor { get; set; }
         int OverlayHeight { get; set; }
         int OverlayWidth { get; set; }
         int CardHeight { get; set; }
@@ -27,6 +29,7 @@ namespace ArkhamOverlay.Services {
             Packs = new List<Pack>();
         }
                 
+        public Color OverlayColor { get; set; }
         public int OverlayHeight { get; set; }
         public int OverlayWidth { get; set; }
         public int CardHeight { get; set; }
@@ -53,6 +56,7 @@ namespace ArkhamOverlay.Services {
 
         public void Load() {
             var configuration = new ConfigurationFile {
+                OverlayColor = (Color)ColorConverter.ConvertFromString("#00B164"),
                 OverlayWidth = 1228,
                 OverlayHeight = 720,
                 CardHeight = 300,
@@ -82,6 +86,7 @@ namespace ArkhamOverlay.Services {
 
     public static class ConfigurationExtensions {
         public static void CopyTo(this IConfiguration fromConfiguration, IConfiguration toConfiguration) {
+            toConfiguration.OverlayColor = fromConfiguration.OverlayColor;
             toConfiguration.OverlayHeight = fromConfiguration.OverlayHeight;
             toConfiguration.OverlayWidth = fromConfiguration.OverlayWidth;
             toConfiguration.CardHeight = fromConfiguration.CardHeight;

--- a/ArkhamOverlay/Services/ConfigurationService.cs
+++ b/ArkhamOverlay/Services/ConfigurationService.cs
@@ -49,6 +49,8 @@ namespace ArkhamOverlay.Services {
     }
 
     public class ConfigurationService {
+        public static Color DefaultBackgroundColor = (Color)ColorConverter.ConvertFromString("#00B164");
+
         private readonly Configuration _configuration;
         public ConfigurationService(AppData appData) {
             _configuration = appData.Configuration;
@@ -56,7 +58,7 @@ namespace ArkhamOverlay.Services {
 
         public void Load() {
             var configuration = new ConfigurationFile {
-                OverlayColor = (Color)ColorConverter.ConvertFromString("#00B164"),
+                OverlayColor = DefaultBackgroundColor,
                 OverlayWidth = 1228,
                 OverlayHeight = 720,
                 CardHeight = 300,

--- a/ArkhamOverlay/Utils/ColorToBrushConverter.cs
+++ b/ArkhamOverlay/Utils/ColorToBrushConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Media;
+
+namespace ArkhamOverlay.Utils {
+    class ColorToBrushConverter : IValueConverter {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture) {
+            if(value is Color color) {
+                return new SolidColorBrush(color);
+            }
+
+            return null;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) {
+            if(value is SolidColorBrush brush) {
+                return brush.Color;
+            }
+
+            return null;
+        }
+    }
+}

--- a/ArkhamOverlay/packages.config
+++ b/ArkhamOverlay/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.2" targetFramework="net472" />
+  <package id="Extended.Wpf.Toolkit" version="4.0.2" targetFramework="net472" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.0.0" targetFramework="net472" />
   <package id="MvvmLightLibs" version="5.4.1.1" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />


### PR DESCRIPTION
Add color picker for overlay background color and button to reset to default (the static color we had before).
Also saves the chosen color in the config file.

Utilizes color picker from the [Extended WPF Toolkit](https://github.com/xceedsoftware/wpftoolkit)

![image](https://user-images.githubusercontent.com/11531010/104834066-f15e0c80-5851-11eb-9567-81ef45685a55.png)



