### PR TITLE
Add button to show all windows

### DIFF
--- a/ArkhamOverlay/Pages/Main/MainController.cs
+++ b/ArkhamOverlay/Pages/Main/MainController.cs
@@ -233,5 +233,15 @@ namespace ArkhamOverlay.Pages.Main {
         public void ClearCards() {
             ViewModel.AppData.Game.ClearAllCards();
         }
+
+        [Command]
+        public void ShowAllWindows() {
+            if (_overlayController != null) {
+                _overlayController.Activate();
+            }
+            foreach (var selectCardsWindow in _selectCardsControllers) {
+                selectCardsWindow.Activate();
+            }
+        }
     }
 }

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -148,6 +148,7 @@
         <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">
             <Button Command="{Binding ShowOverlay}">Show Overlay</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding ClearCards}">Clear Cards</Button>
+            <Button Margin="10, 0, 0, 0" Command="{Binding ShowAllWindows}">Show All Windows</Button>
         </StackPanel>
     </StackPanel>
 </Window>


### PR DESCRIPTION
Add a button to show all windows. This only shows any windows that are currently open but not in foreground.

Name might be confusing with  "Show Overlay" button which creates the overlay window.