### PR TITLE
Split snapshots

### DIFF
--- a/ArkhamOverlay/Data/Card.cs
+++ b/ArkhamOverlay/Data/Card.cs
@@ -2,12 +2,9 @@
 using ArkhamOverlay.Services;
 using ArkhamOverlay.Utils;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Windows;
 using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Threading;
 
 namespace ArkhamOverlay.Data {
     public delegate void CardToggledEvent(ICardButton card);
@@ -34,7 +31,7 @@ namespace ArkhamOverlay.Data {
             if (Application.Current == null) {
                 return;
             }
-            this.LoadImage("https://arkhamdb.com/" + ImageSource);
+            this.LoadImage(ImageSource);
         }
 
         public Card(LocalManifestCard localCard, bool cardBack) {
@@ -45,7 +42,7 @@ namespace ArkhamOverlay.Data {
             Xp = 0;
             Faction = Faction.Other;
             Type = (CardType)Enum.Parse(typeof(CardType), localCard.CardType);
-            ImageSource = cardBack ? Path.GetDirectoryName(localCard.FilePath) + "\\" + Path.GetFileNameWithoutExtension(localCard.FilePath) + "-back" + Path.GetExtension(localCard.FilePath) : localCard.FilePath;
+            ImageSource = cardBack ? localCard.BackFilePath : localCard.FilePath;
             IsPlayerCard = false;
             if (cardBack) {
                 Name += " (Back)";

--- a/ArkhamOverlay/Data/Configuration.cs
+++ b/ArkhamOverlay/Data/Configuration.cs
@@ -47,6 +47,15 @@ namespace ArkhamOverlay.Data {
             }
         }
 
+        private bool _seperateStatSnapshots;
+        public bool SeperateStatSnapshots {
+            get => _seperateStatSnapshots;
+            set {
+                _seperateStatSnapshots = value;
+                OnConfigurationChange();
+            }
+        }
+
         private Color _overlayColor;
         public Color OverlayColor {
             get => _overlayColor;

--- a/ArkhamOverlay/Data/LocalPackManifest.cs
+++ b/ArkhamOverlay/Data/LocalPackManifest.cs
@@ -11,10 +11,29 @@ namespace ArkhamOverlay.Data {
         public IList<LocalManifestCard> Cards { get; set; }
     }
 
-    public class LocalManifestCard {
+    public interface ILocalCard {
+        string FilePath { get; set; }
+        string Name { get; set; }
+        bool HasBack { get; set; }
+        string CardType { get; set; }
+        string ArkhamDbId { get; set; }
+    }
+
+    public class LocalManifestCard : ILocalCard {
         public string FilePath { get; set; }
         public string Name { get; set; }
         public bool HasBack { get; set; }
         public string CardType { get; set; }
+        public string ArkhamDbId { get; set; }
+    }
+
+    public static class LocalCardExtensions {
+        public static void CopyTo(this ILocalCard sourceCard, ILocalCard destinationCard) {
+            destinationCard.FilePath = sourceCard.FilePath;
+            destinationCard.Name = sourceCard.Name;
+            destinationCard.HasBack = sourceCard.HasBack;
+            destinationCard.CardType = sourceCard.CardType;
+            destinationCard.ArkhamDbId = sourceCard.ArkhamDbId;
+        }
     }
 }

--- a/ArkhamOverlay/Data/LocalPackManifest.cs
+++ b/ArkhamOverlay/Data/LocalPackManifest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 
 namespace ArkhamOverlay.Data {
     public class LocalPackManifest {
@@ -25,6 +26,12 @@ namespace ArkhamOverlay.Data {
         public bool HasBack { get; set; }
         public string CardType { get; set; }
         public string ArkhamDbId { get; set; }
+
+        public string BackFilePath { 
+            get {
+                return Path.GetDirectoryName(FilePath) + "\\" + Path.GetFileNameWithoutExtension(FilePath) + "-back" + Path.GetExtension(FilePath);
+            } 
+        }
     }
 
     public static class LocalCardExtensions {

--- a/ArkhamOverlay/Pages/LocalImages/LocalImagesController.cs
+++ b/ArkhamOverlay/Pages/LocalImages/LocalImagesController.cs
@@ -88,7 +88,7 @@ namespace ArkhamOverlay.Pages.LocalImages {
             try {
                 var card = pack.Cards.FirstOrDefault(x => string.Equals(x.FilePath, filePath, StringComparison.InvariantCulture));
                 if (card == null) {
-                    card = new LocalCard(filePath);
+                    card = new LocalCard { FilePath = filePath } ;
                     card.PropertyChanged += (s, e) => {
                         WriteManifest();
                     };
@@ -125,11 +125,8 @@ namespace ArkhamOverlay.Pages.LocalImages {
             var localCards = new ObservableCollection<LocalCard>();
             foreach (var card in manifest.Cards) {
                 if (File.Exists(card.FilePath)) {
-                    var localCard = new LocalCard(card.FilePath) {
-                        CardType = card.CardType,
-                        Name = card.Name,
-                        HasBack = card.HasBack
-                    };
+                    var localCard = new LocalCard();
+                    card.CopyTo(localCard);
 
                     localCard.PropertyChanged += (s, e) => {
                         WriteManifest();
@@ -157,12 +154,9 @@ namespace ArkhamOverlay.Pages.LocalImages {
                 };
 
                 foreach (var card in pack.Cards) {
-                manifest.Cards.Add(new LocalManifestCard {
-                        FilePath = card.FilePath,
-                        Name = card.Name,
-                        CardType = card.CardType,
-                        HasBack = card.HasBack
-                    });
+                    var localManifestCard = new LocalManifestCard();
+                    card.CopyTo(localManifestCard);
+                    manifest.Cards.Add(localManifestCard);
                 }
 
                 File.WriteAllText(manifestPath, JsonConvert.SerializeObject(manifest));

--- a/ArkhamOverlay/Pages/LocalImages/LocalImagesController.cs
+++ b/ArkhamOverlay/Pages/LocalImages/LocalImagesController.cs
@@ -16,7 +16,7 @@ namespace ArkhamOverlay.Pages.LocalImages {
         private readonly AppData _appData;
         private readonly LoggingService _logger;
 
-        public LocalImagesController(AppData appData, LoggingService logger) {
+        public LocalImagesController(AppData appData, LoggingService logger, LocalCardsService localCardsService) {
             _appData = appData;
             _logger = logger;
             ViewModel.Configuration = appData.Configuration;
@@ -24,6 +24,7 @@ namespace ArkhamOverlay.Pages.LocalImages {
             LoadPacks();
 
             View.Closed += (s, e) => {
+                localCardsService.InvalidateManifestCache();
                 appData.Game.OnEncounterSetsChanged();
             };
         }

--- a/ArkhamOverlay/Pages/LocalImages/LocalImagesView.xaml
+++ b/ArkhamOverlay/Pages/LocalImages/LocalImagesView.xaml
@@ -45,14 +45,17 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                     <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Card Name:" Margin="0, 0, 10, 10"/>
                 <TextBox Grid.Row="0" Grid.Column="1" Margin="5,0,5,10" Text="{Binding SelectedPack.SelectedCard.Name, Mode=TwoWay}" />
                 <TextBlock Grid.Row="1" Grid.Column="0" Text="Card Type:" Margin="0, 0, 10, 0"/>
                 <ComboBox Grid.Row="1" Grid.Column="1"  Margin="5,0,5,0" ItemsSource="{Binding CardTypes}" SelectedItem="{Binding SelectedPack.SelectedCard.CardType, Mode=TwoWay}" />
+                <TextBlock Grid.Row="2" Grid.Column="0" Text="ArkahmDB ID:" Margin="0, 10, 10, 10"/>
+                <TextBox Grid.Row="2" Grid.Column="1" Margin="5,10,5,10" Text="{Binding SelectedPack.SelectedCard.ArkhamDbId, Mode=TwoWay}" />
                 <Image 
-                    Grid.Row="2" 
+                    Grid.Row="3" 
                     Grid.Column="0" 
                     Grid.ColumnSpan="2" 
                     MaxHeight="400" 

--- a/ArkhamOverlay/Pages/LocalImages/LocalImagesViewModel.cs
+++ b/ArkhamOverlay/Pages/LocalImages/LocalImagesViewModel.cs
@@ -65,13 +65,17 @@ namespace ArkhamOverlay.Pages.LocalImages {
         public virtual ObservableCollection<LocalCard> Cards { get; set; }
     }
 
-    public class LocalCard : ViewModel {
-        public LocalCard(string path) {
-            FilePath = path;
-            Name = Path.GetFileNameWithoutExtension(path);
+    public class LocalCard : ViewModel, ILocalCard {
+        private string _filePath;
+        public virtual string FilePath {
+            get => _filePath; 
+            set {
+                _filePath = value;
+                if (string.IsNullOrEmpty(Name)) {
+                    Name = Path.GetFileNameWithoutExtension(_filePath);
+                }
+            }
         }
-
-        public virtual string FilePath { get; }
 
         private string _name;
         public virtual string Name{
@@ -91,12 +95,20 @@ namespace ArkhamOverlay.Pages.LocalImages {
             }
         }
 
+        private string _arkhamDbId;
+        public virtual string ArkhamDbId {
+            get => _arkhamDbId;
+            set {
+                _arkhamDbId = value;
+                NotifyPropertyChanged(nameof(ArkhamDbId));
+            }
+        }
+
         public virtual bool HasBack { get; set; }
 
         public virtual ImageSource Image { get; set; }
         public virtual ImageSource FrontThumbnail { get; set; }
         public virtual ImageSource BackThumbnail { get; set; }
-
         public Rect ClipRect { get; set; }
     }
 }

--- a/ArkhamOverlay/Pages/Main/MainView.xaml
+++ b/ArkhamOverlay/Pages/Main/MainView.xaml
@@ -233,6 +233,7 @@
             <Button Margin="10, 0, 0, 0" Command="{Binding ShowAllWindows}">Show All Windows</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding ClearCards}" Visibility="{Binding OverlayDisplayed, Converter={StaticResource BoolToVisibility}}">Clear Cards</Button>
             <Button Margin="10, 0, 0, 0" Command="{Binding TakeSnapshot}" Visibility="{Binding OverlayDisplayed, Converter={StaticResource BoolToVisibility}}">Snapshot</Button>
+            <CheckBox Margin="10, 1, 0, 0" IsChecked="{Binding Configuration.SeperateStatSnapshots}">Seperate Stat Snapshots</CheckBox>
         </StackPanel>
         <StackPanel Orientation="Vertical" Margin="0, 0, 0, 0">
             <StackPanel Orientation="Horizontal" Margin="0, 10, 0, 0">

--- a/ArkhamOverlay/Pages/Overlay/OverlayController.cs
+++ b/ArkhamOverlay/Pages/Overlay/OverlayController.cs
@@ -384,14 +384,24 @@ namespace ArkhamOverlay.Pages.Overlay {
 
         internal void TakeSnapshot() {
             _logger.LogMessage("Taking snapshot of overlay window.");
-            var fileName = _appData.Game.SnapshotDirectory + "OverlaySnapshot" + DateTime.Now.ToString("yyddMHHmmss") + ".png";
-            WriteSnapshotToFile(fileName);
+
+            var timeStamp = DateTime.Now.ToString("yyddMHHmmss");
+
+            if (_appData.Configuration.SeperateStatSnapshots) {
+                WriteSnapshotToFile($"{_appData.Game.SnapshotDirectory}\\OverlaySnapshot{timeStamp}.png", View.Cards);
+                WriteSnapshotToFile($"{_appData.Game.SnapshotDirectory}\\OverlaySnapshot{timeStamp}-Stats.png", View.Stats);
+            } else {
+                WriteSnapshotToFile($"{_appData.Game.SnapshotDirectory}\\OverlaySnapshot{timeStamp}.png");
+            }
         }
 
-        private void WriteSnapshotToFile(string file) {
-            var overlay = View.Overlay;
-            var renderTargetBitmap = new RenderTargetBitmap(Convert.ToInt32(overlay.Width), Convert.ToInt32(overlay.Height), 96, 96, PixelFormats.Pbgra32);
-            renderTargetBitmap.Render(overlay);
+        private void WriteSnapshotToFile(string file, FrameworkElement controlToSnapshot = null) {
+            if (controlToSnapshot == null) {
+                controlToSnapshot = View.Overlay;
+            }
+            
+            var renderTargetBitmap = new RenderTargetBitmap(Convert.ToInt32(controlToSnapshot.ActualWidth), Convert.ToInt32(controlToSnapshot.ActualHeight), 96, 96, PixelFormats.Pbgra32);
+            renderTargetBitmap.Render(controlToSnapshot);
             var pngImage = new PngBitmapEncoder();
             pngImage.Frames.Add(BitmapFrame.Create(renderTargetBitmap));
             try {

--- a/ArkhamOverlay/Pages/Overlay/OverlayView.xaml
+++ b/ArkhamOverlay/Pages/Overlay/OverlayView.xaml
@@ -38,20 +38,20 @@
 
         <DockPanel Grid.Row="0"
                    LastChildFill="false"
-                   Margin="0, -5, 0, 10"
-                   Visibility="{Binding ShowDeckList, Converter={StaticResource BoolToVisibilityCollapsed}}">
-            <DockPanel DockPanel.Dock="Top" LastChildFill="false">
+                   Visibility="{Binding ShowDeckList, Converter={StaticResource BoolToVisibilityCollapsed}}"
+                   x:Name="Stats">
+            <DockPanel DockPanel.Dock="Top" LastChildFill="false" Margin="0, -5, 0, 0">
                 <overlay:StatDisplay DockPanel.Dock="Left"  DataContext="{Binding AppData.Game.Players[0]}" />
                 <overlay:StatDisplay DockPanel.Dock="Right" DataContext="{Binding AppData.Game.Players[1]}" ImageAlignment="Right" />
             </DockPanel>
 
-            <DockPanel DockPanel.Dock="Bottom"  LastChildFill="false">
+            <DockPanel DockPanel.Dock="Bottom"  LastChildFill="false"  Margin="0, -5, 0, 10">
                 <overlay:StatDisplay  DockPanel.Dock="Left" DataContext="{Binding AppData.Game.Players[2]}" />
                 <overlay:StatDisplay DockPanel.Dock="Right" DataContext="{Binding AppData.Game.Players[3]}" ImageAlignment="Right"/>
             </DockPanel>
         </DockPanel>
 
-        <Grid>
+        <Grid x:Name="Cards">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>

--- a/ArkhamOverlay/Services/ArkhamDbService.cs
+++ b/ArkhamOverlay/Services/ArkhamDbService.cs
@@ -1,6 +1,4 @@
-﻿using ArkhamOverlay.CardButtons;
-using ArkhamOverlay.Data;
-using ArkhamOverlay.Pages.Main;
+﻿using ArkhamOverlay.Data;
 using ArkhamOverlay.Utils;
 using Newtonsoft.Json;
 using System;

--- a/ArkhamOverlay/Services/ArkhamDbService.cs
+++ b/ArkhamOverlay/Services/ArkhamDbService.cs
@@ -11,10 +11,12 @@ namespace ArkhamOverlay.Services {
     public class ArkhamDbService {
         private readonly LoggingService _logger;
         private readonly AppData _appData;
+        private readonly LocalCardsService _localCardsService;
 
-        public ArkhamDbService(LoggingService loggingService, AppData appData) {
+        public ArkhamDbService(LoggingService loggingService, AppData appData, LocalCardsService localCardsService) {
             _logger = loggingService;
             _appData = appData;
+            _localCardsService = localCardsService;
         }
 
         internal void LoadPlayer(Player player) {
@@ -36,7 +38,12 @@ namespace ArkhamOverlay.Services {
                 player.SelectableCards.Name = arkhamDbDeck.Investigator_Name;
                 player.InvestigatorCode = arkhamDbDeck.Investigator_Code;
                 player.Slots = arkhamDbDeck.Slots;
-                player.LoadImage("https://arkhamdb.com/bundles/cards/" + arkhamDbDeck.Investigator_Code + ".png");
+                var localCard = _localCardsService.GetCardById(arkhamDbDeck.Investigator_Code);
+                if (localCard != null) {
+                    player.LoadImage(localCard.FilePath);
+                } else {
+                    player.LoadImage("https://arkhamdb.com/bundles/cards/" + arkhamDbDeck.Investigator_Code + ".png");
+                }
             }
 
             _logger.LogMessage($"Loading investigator card for player {player.ID}.");
@@ -79,6 +86,7 @@ namespace ArkhamOverlay.Services {
                     using (Stream cardStream = cardRsponse.GetResponseStream())
                     using (StreamReader cardReader = new StreamReader(cardStream)) {
                         var arkhamDbCard = JsonConvert.DeserializeObject<ArkhamDbCard>(cardReader.ReadToEnd());
+                        CheckForLocalImages(arkhamDbCard);
                         cards.Add(new Card(arkhamDbCard, slot.Value, true));
                     }
                 }
@@ -90,6 +98,19 @@ namespace ArkhamOverlay.Services {
                 player.SelectableCards.Loading = false;
             }
             _logger.LogMessage($"Finished loading cards for player {player.ID}.");
+        }
+
+        private void CheckForLocalImages(ArkhamDbCard arkhamDbCard) {
+            var localCard = _localCardsService.GetCardById(arkhamDbCard.Code);
+            if (localCard != null) {
+                arkhamDbCard.ImageSrc = localCard.FilePath;
+                if (localCard.HasBack) {
+                    arkhamDbCard.BackImageSrc = localCard.BackFilePath;
+                }
+            } else {
+                if (!string.IsNullOrEmpty(arkhamDbCard.ImageSrc)) arkhamDbCard.ImageSrc = "https://arkhamdb.com/" + arkhamDbCard.ImageSrc;
+                if (!string.IsNullOrEmpty(arkhamDbCard.BackImageSrc)) arkhamDbCard.ImageSrc = "https://arkhamdb.com/" + arkhamDbCard.BackImageSrc;
+            }
         }
 
         internal void FindMissingEncounterSets(Configuration configuration) {
@@ -170,6 +191,8 @@ namespace ArkhamOverlay.Services {
                     if (!_appData.Game.IsEncounterSetSelected(arkhamDbCard.Encounter_Code)) {
                         continue;
                     }
+
+                    CheckForLocalImages(arkhamDbCard);
 
                     var newCard = new Card(arkhamDbCard, 1, false);
                     cards.Add(newCard);

--- a/ArkhamOverlay/Services/ConfigurationService.cs
+++ b/ArkhamOverlay/Services/ConfigurationService.cs
@@ -11,6 +11,7 @@ namespace ArkhamOverlay.Services {
         bool TrackHealthAndSanity { get; set; }
         bool TrackResources { get; set; }
         bool TrackClues { get; set; }
+        bool SeperateStatSnapshots { get; set; }
         Color OverlayColor { get; set; }
         int OverlayHeight { get; set; }
         int OverlayWidth { get; set; }
@@ -39,6 +40,7 @@ namespace ArkhamOverlay.Services {
         public bool TrackHealthAndSanity { get; set; }
         public bool TrackResources { get; set; }
         public bool TrackClues { get; set; }
+        public bool SeperateStatSnapshots { get; set; }
         public Color OverlayColor { get; set; }
         public int OverlayHeight { get; set; }
         public int OverlayWidth { get; set; }
@@ -115,6 +117,7 @@ namespace ArkhamOverlay.Services {
             toConfiguration.TrackHealthAndSanity = fromConfiguration.TrackHealthAndSanity;
             toConfiguration.TrackResources = fromConfiguration.TrackResources;
             toConfiguration.TrackClues = fromConfiguration.TrackClues;
+            toConfiguration.SeperateStatSnapshots = fromConfiguration.SeperateStatSnapshots;
             toConfiguration.OverlayColor = fromConfiguration.OverlayColor;
             toConfiguration.OverlayHeight = fromConfiguration.OverlayHeight;
             toConfiguration.OverlayWidth = fromConfiguration.OverlayWidth;


### PR DESCRIPTION
Simple change so that a user can use seperate layers for stat overlays and card overlays

note: this does not affect auto snapshots