### PR TITLE
Add cache of all cards for bonded cards

### DIFF
--- a/ArkhamOverlay/Data/Card.cs
+++ b/ArkhamOverlay/Data/Card.cs
@@ -16,7 +16,7 @@ namespace ArkhamOverlay.Data {
         public Card() {
         }
 
-        public Card(ArkhamDbCard arkhamDbCard, int count, bool isPlayerCard, bool cardBack = false) {
+        public Card(ArkhamDbCard arkhamDbCard, int count, bool isPlayerCard, bool cardBack = false, bool isBonded = false) {
             Code = arkhamDbCard.Code;
             Count = count;
             Name = arkhamDbCard.Xp == "0" || string.IsNullOrEmpty(arkhamDbCard.Xp) ? arkhamDbCard.Name : arkhamDbCard.Name + " (" + arkhamDbCard.Xp + ")";
@@ -26,6 +26,7 @@ namespace ArkhamOverlay.Data {
             Type = GetCardType(arkhamDbCard.Type_Code);
             ImageSource = cardBack ? arkhamDbCard.BackImageSrc : arkhamDbCard.ImageSrc;
             IsPlayerCard = isPlayerCard;
+            IsBonded = isBonded;
             if (cardBack) {
                 Name += " (Back)";
             }
@@ -68,6 +69,7 @@ namespace ArkhamOverlay.Data {
         public ImageSource Image { get; set; }
         public ImageSource ButtonImage { get; set; }
         public byte[] ButtonImageAsBytes { get; set; }
+        public bool IsBonded { get; }
 
         public CardType Type { get; }
         

--- a/ArkhamOverlay/Pages/Overlay/OverlayController.cs
+++ b/ArkhamOverlay/Pages/Overlay/OverlayController.cs
@@ -243,7 +243,13 @@ namespace ArkhamOverlay.Pages.Overlay {
                         select cardButton.Card;
 
             var deckList = new List<DeckListItem>();
-            foreach (var card in cards) {
+            foreach (var card in cards.Where(c => !c.IsBonded)) {
+                deckList.Add(new DeckListItem(card));
+            }
+
+            deckList.Add(new DeckListItem("Bonded Cards"));
+
+            foreach (var card in cards.Where(c => c.IsBonded)) {
                 deckList.Add(new DeckListItem(card));
             }
 

--- a/ArkhamOverlay/Pages/Overlay/OverlayViewModel.cs
+++ b/ArkhamOverlay/Pages/Overlay/OverlayViewModel.cs
@@ -36,12 +36,21 @@ namespace ArkhamOverlay.Pages.Overlay {
 
     public class DeckListItem {
         private Card _card;
+        private string _name;
+
         public DeckListItem(Card card) {
             _card = card;
         }
 
+        public DeckListItem(string name) {
+            _name = name;
+        }
+
         public string Name { 
             get {
+                if(!string.IsNullOrEmpty(_name)) {
+                    return _name;
+                }
                 var name = _card.NameWithoutXp;
                 for (var x = 0; x < _card.Xp; x++) {
                     name += "•";
@@ -52,7 +61,11 @@ namespace ArkhamOverlay.Pages.Overlay {
         }
 
         public Brush Foreground { 
-            get { 
+            get {
+                if (_card == null) {
+                    return new SolidColorBrush(Colors.Black);
+                }
+
                 switch (_card.Faction) {
                     case Faction.Guardian: return new SolidColorBrush(Colors.DarkBlue);
                     case Faction.Seeker: return new SolidColorBrush(Colors.DarkGoldenrod);

--- a/ArkhamOverlay/Services/ArkhamDbService.cs
+++ b/ArkhamOverlay/Services/ArkhamDbService.cs
@@ -43,18 +43,12 @@ namespace ArkhamOverlay.Services {
 
             _logger.LogMessage($"Loading investigator card for player {player.ID}.");
 
-            var investigatorUrl = @"https://arkhamdb.com/api/public/card/" + player.InvestigatorCode;
-            var investigatorRequest = (HttpWebRequest)WebRequest.Create(investigatorUrl);
-            using (var response = (HttpWebResponse)investigatorRequest.GetResponse())
-            using (var stream = response.GetResponseStream())
-            using (var reader = new StreamReader(stream)) {
-                var arkhamDbCard = JsonConvert.DeserializeObject<ArkhamDbCard>(reader.ReadToEnd());
+            var playerCard = GetCard(player.InvestigatorCode);
 
-                if (Enum.TryParse(arkhamDbCard.Faction_Name, ignoreCase: true, out Faction faction)) {
-                    player.Faction = faction;
-                } else {
-                    _logger.LogWarning($"Could not parse faction {arkhamDbCard.Faction_Name}.");
-                }
+            if (Enum.TryParse(playerCard.Faction_Name, ignoreCase: true, out Faction faction)) {
+                player.Faction = faction;
+            } else {
+                _logger.LogWarning($"Could not parse faction {playerCard.Faction_Name}.");
             }
 
             _logger.LogMessage($"Finished loading player {player.ID}.");
@@ -74,15 +68,10 @@ namespace ArkhamOverlay.Services {
             try {
                 var cards = new List<Card>();
                 foreach (var slot in player.Slots) {
-                    var baseCardUrl = @"https://arkhamdb.com/api/public/card/";
-                    HttpWebRequest cardRequest = (HttpWebRequest)WebRequest.Create(baseCardUrl + slot.Key);
-
-                    using (HttpWebResponse cardRsponse = (HttpWebResponse)cardRequest.GetResponse())
-                    using (Stream cardStream = cardRsponse.GetResponseStream())
-                    using (StreamReader cardReader = new StreamReader(cardStream)) {
-                        var arkhamDbCard = JsonConvert.DeserializeObject<ArkhamDbCard>(cardReader.ReadToEnd());
-                        cards.Add(new Card(arkhamDbCard, slot.Value, true));
-                    }
+                    var arkhamDbCard = GetCard(slot.Key);
+                    cards.Add(new Card(arkhamDbCard, slot.Value, true));
+                    var bondedCards = LocalCardCache.Instance.GetBondedCards(arkhamDbCard);
+                    cards.AddRange(bondedCards.Select(c => new Card(c.Key, c.Value, isPlayerCard:true, isBonded:true)));
                 }
                 player.SelectableCards.LoadCards(cards);
             }
@@ -196,6 +185,87 @@ namespace ArkhamOverlay.Services {
             using (StreamReader cardReader = new StreamReader(cardStream)) {
                 return JsonConvert.DeserializeObject<IList<ArkhamDbCard>>(cardReader.ReadToEnd());
             }
+        }
+
+        private ArkhamDbCard GetCard(string cardCode) {
+            var baseCardUrl = @"https://arkhamdb.com/api/public/card/";
+            HttpWebRequest cardRequest = (HttpWebRequest)WebRequest.Create(baseCardUrl + cardCode);
+            try {
+                using (HttpWebResponse cardRsponse = (HttpWebResponse)cardRequest.GetResponse())
+                using (Stream cardStream = cardRsponse.GetResponseStream())
+                using (StreamReader cardReader = new StreamReader(cardStream)) {
+                    var arkhamDbCard = JsonConvert.DeserializeObject<ArkhamDbCard>(cardReader.ReadToEnd());
+                    return arkhamDbCard;
+                }
+            } catch (Exception ex) {
+                _logger.LogException(ex, $"Error fetching card with code: {cardCode}");
+                return null;
+            }
+        }
+
+        private class LocalCardCache {
+            public static LocalCardCache Instance = new LocalCardCache();
+
+            private object syncObject = new object();
+            private bool initialized = false;
+            private List<ArkhamDbFullCard> allCards = new List<ArkhamDbFullCard>();
+
+            private LocalCardCache() {
+            }
+
+            public void Initialize() {
+                if (!initialized) {
+                    lock (syncObject) {
+                        if (!initialized) {
+                            try {
+                                var cardsURL = @"https://arkhamdb.com/api/public/cards/";
+                                HttpWebRequest cardsRequest = (HttpWebRequest)WebRequest.Create(cardsURL);
+
+                                using (HttpWebResponse cardRsponse = (HttpWebResponse)cardsRequest.GetResponse())
+                                using (Stream cardStream = cardRsponse.GetResponseStream())
+                                using (StreamReader cardReader = new StreamReader(cardStream)) {
+                                    allCards = JsonConvert.DeserializeObject<List<ArkhamDbFullCard>>(cardReader.ReadToEnd());
+                                    initialized = true;
+                                }
+                            }
+                            catch {
+                                // Best effort attempt, do nothing if it fails.
+                            }
+                        }
+                    }
+                }
+            }
+
+            public ArkhamDbFullCard GetCard(string code) {
+                Initialize();
+
+                return allCards.FirstOrDefault(c => c.Code.Equals(code));
+            }
+
+            public Dictionary<ArkhamDbCard, int> GetBondedCards(ArkhamDbCard card) {
+                Initialize();
+
+                if (!(card is ArkhamDbFullCard mainCard)) {
+                    mainCard = allCards.FirstOrDefault(c => c.Code.Equals(card.Code));
+                }
+
+                var bondedCards = new Dictionary<ArkhamDbCard, int>();
+                if (mainCard != null && mainCard.Bonded_Cards != null) {
+                    foreach (var bondedCard in mainCard.Bonded_Cards) {
+                        bondedCards.Add(allCards.FirstOrDefault(c => c.Code.Equals(bondedCard.Code)), bondedCard.Count);
+                    }
+                }
+                return bondedCards;
+            }
+        }
+
+        public class ArkhamDbFullCard : ArkhamDbCard {
+            public List<BondedCard> Bonded_Cards;
+        }
+
+        public class BondedCard {
+            public int Count;
+            public string Code;
         }
     }
 }

--- a/ArkhamOverlay/Services/ArkhamDbService.cs
+++ b/ArkhamOverlay/Services/ArkhamDbService.cs
@@ -235,23 +235,20 @@ namespace ArkhamOverlay.Services {
             }
 
             public void Initialize() {
-                if (!initialized) {
-                    lock (syncObject) {
-                        if (!initialized) {
-                            try {
-                                var cardsURL = @"https://arkhamdb.com/api/public/cards/";
-                                HttpWebRequest cardsRequest = (HttpWebRequest)WebRequest.Create(cardsURL);
+                lock (syncObject) {
+                    if (!initialized) {
+                        try {
+                            var cardsURL = @"https://arkhamdb.com/api/public/cards/";
+                            HttpWebRequest cardsRequest = (HttpWebRequest)WebRequest.Create(cardsURL);
 
-                                using (HttpWebResponse cardRsponse = (HttpWebResponse)cardsRequest.GetResponse())
-                                using (Stream cardStream = cardRsponse.GetResponseStream())
-                                using (StreamReader cardReader = new StreamReader(cardStream)) {
-                                    allCards = JsonConvert.DeserializeObject<List<ArkhamDbFullCard>>(cardReader.ReadToEnd());
-                                    initialized = true;
-                                }
+                            using (HttpWebResponse cardRsponse = (HttpWebResponse)cardsRequest.GetResponse())
+                            using (Stream cardStream = cardRsponse.GetResponseStream())
+                            using (StreamReader cardReader = new StreamReader(cardStream)) {
+                                allCards = JsonConvert.DeserializeObject<List<ArkhamDbFullCard>>(cardReader.ReadToEnd());
+                                initialized = true;
                             }
-                            catch {
-                                // Best effort attempt, do nothing if it fails.
-                            }
+                        } catch {
+                            // Best effort attempt, do nothing if it fails.
                         }
                     }
                 }


### PR DESCRIPTION
Add in-memory cache of all cards so we can look up bonded cards. Add bonded field so we can differentiate in the deck list view.

The cache isn't really optimized, but I think we can leave that for later when we refactor the card loading services.