### PR TITLE
Cards with same name defects

### DIFF
--- a/ArkhamOverlay.Common/Events/ButtonInfoChanged.cs
+++ b/ArkhamOverlay.Common/Events/ButtonInfoChanged.cs
@@ -9,11 +9,12 @@ namespace ArkhamOverlay.Events {
     public enum ChangeAction { Add, Update }
 
     public class ButtonInfoChanged : ICrossAppEvent, IButtonContext, ICardInfo {
-        public ButtonInfoChanged(CardGroupId cardGroupId, ButtonMode buttonMode, int index, string name, bool isToggled, bool imageAvailable, ChangeAction action, IList<ButtonOption> buttonOptions) {
+        public ButtonInfoChanged(CardGroupId cardGroupId, ButtonMode buttonMode, int index, string name, string code, bool isToggled, bool imageAvailable, ChangeAction action, IList<ButtonOption> buttonOptions) {
             CardGroupId = cardGroupId;
             ButtonMode = buttonMode;
             Index = index;
             Name = name;
+            Code = code;
             IsToggled = isToggled;
             ImageAvailable = imageAvailable;
             Action = action;
@@ -24,6 +25,7 @@ namespace ArkhamOverlay.Events {
         public ButtonMode ButtonMode { get; }
         public int Index { get; }
         public string Name { get; }
+        public string Code { get; }
         public bool IsToggled { get; }
         public bool ImageAvailable { get; }
         public ChangeAction Action { get; }
@@ -31,8 +33,8 @@ namespace ArkhamOverlay.Events {
     }
 
     public static class ButtonInfoChangedExtensions {
-        public static void PublishButtonInfoChanged(this IEventBus eventBus, CardGroupId cardGroupId, ButtonMode buttonMode, int index, string name, bool isToggled, bool imageAvailable, ChangeAction action, IList<ButtonOption> buttonOptions) {
-            eventBus.Publish(new ButtonInfoChanged(cardGroupId, buttonMode, index, name, isToggled, imageAvailable, action, buttonOptions));
+        public static void PublishButtonInfoChanged(this IEventBus eventBus, CardGroupId cardGroupId, ButtonMode buttonMode, int index, string name, string code, bool isToggled, bool imageAvailable, ChangeAction action, IList<ButtonOption> buttonOptions) {
+            eventBus.Publish(new ButtonInfoChanged(cardGroupId, buttonMode, index, name, code, isToggled, imageAvailable, action, buttonOptions));
         }
 
         public static void SubscribeToButtonInfoChanged(this IEventBus eventBus, Action<ButtonInfoChanged> callback) {

--- a/ArkhamOverlay.Common/Events/CardTemplateVisibilityChanged.cs
+++ b/ArkhamOverlay.Common/Events/CardTemplateVisibilityChanged.cs
@@ -3,18 +3,18 @@ using System;
 
 namespace ArkhamOverlay.Events {
     public class CardInfoVisibilityChanged : ICrossAppEvent {
-        public CardInfoVisibilityChanged(string name, bool isVisible) {
-            Name = name;
+        public CardInfoVisibilityChanged(string code, bool isVisible) {
+            Code = code;
             IsVisible = isVisible;
         }
 
-        public string Name;
+        public string Code;
         public bool IsVisible;
     }
 
     public static class CardInfoVisibilityChangedExtensions {
-        public static void PublishCardInfoVisibilityChanged(this IEventBus eventBus, string name, bool isVisible) {
-            eventBus.Publish(new CardInfoVisibilityChanged(name, isVisible));
+        public static void PublishCardInfoVisibilityChanged(this IEventBus eventBus, string code, bool isVisible) {
+            eventBus.Publish(new CardInfoVisibilityChanged(code, isVisible));
         }
 
         public static void SubscribeToCardInfoVisibilityChanged(this IEventBus eventBus, Action<CardInfoVisibilityChanged> callback) {

--- a/ArkhamOverlay.Common/ICardInfo.cs
+++ b/ArkhamOverlay.Common/ICardInfo.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 namespace ArkhamOverlay.Common {
     public interface ICardInfo {
         string Name { get; }
+        string Code { get; }
         bool IsToggled { get; }
         bool ImageAvailable { get; }
         IList<ButtonOption> ButtonOptions { get; }

--- a/ArkhamOverlay.Common/Tcp/Responses/ButtonImageResponse.cs
+++ b/ArkhamOverlay.Common/Tcp/Responses/ButtonImageResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace ArkhamOverlay.Common.Tcp.Responses {
     public class ButtonImageResponse : Response {
-        public string Name { get; set; }
+        public string Code { get; set; }
         public byte[] Bytes { get; set; }
     }
 }

--- a/ArkhamOverlay.Common/Tcp/Responses/CardInfoResponse.cs
+++ b/ArkhamOverlay.Common/Tcp/Responses/CardInfoResponse.cs
@@ -6,6 +6,7 @@ namespace ArkhamOverlay.Common.Tcp.Responses {
     public class CardInfoResponse : Response, ICardInfo {
         public CardButtonType CardButtonType { get; set; }
         public string Name { get; set; }
+        public string Code { get; set; }
         public bool IsToggled { get; set; }
         public bool ImageAvailable { get; set; }
         public IList<ButtonOption> ButtonOptions { get; set; }

--- a/ArkhamOverlay/CardButtons/IHasImageButton.cs
+++ b/ArkhamOverlay/CardButtons/IHasImageButton.cs
@@ -3,6 +3,7 @@
 namespace ArkhamOverlay.CardButtons {
     public interface IHasImageButton {
         string Name { get; }
+        string Code { get; }
         CardType ImageCardType { get; }
         string ImageSource { get; set; }
         ImageSource Image { get; set; }

--- a/ArkhamOverlay/CardButtons/IHasImageButton.cs
+++ b/ArkhamOverlay/CardButtons/IHasImageButton.cs
@@ -3,7 +3,8 @@
 namespace ArkhamOverlay.CardButtons {
     public interface IHasImageButton {
         string Name { get; }
-        string Code { get; }
+        //string Code { get; }
+        string ImageId { get; }
         CardType ImageCardType { get; }
         string ImageSource { get; set; }
         ImageSource Image { get; set; }

--- a/ArkhamOverlay/CardButtons/IHasImageButton.cs
+++ b/ArkhamOverlay/CardButtons/IHasImageButton.cs
@@ -3,7 +3,6 @@
 namespace ArkhamOverlay.CardButtons {
     public interface IHasImageButton {
         string Name { get; }
-        //string Code { get; }
         string ImageId { get; }
         CardType ImageCardType { get; }
         string ImageSource { get; set; }

--- a/ArkhamOverlay/Data/CardGroup.cs
+++ b/ArkhamOverlay/Data/CardGroup.cs
@@ -224,7 +224,7 @@ namespace ArkhamOverlay.Data {
             }
 
             foreach (var button in cardImageButtons) {
-                if (e.Name == button.CardInfo.Name) {
+                if (e.Code == button.CardInfo.Code) {
                     button.IsToggled = e.IsVisible;
                 }
             }

--- a/ArkhamOverlay/Data/CardGroup.cs
+++ b/ArkhamOverlay/Data/CardGroup.cs
@@ -224,7 +224,7 @@ namespace ArkhamOverlay.Data {
             }
 
             foreach (var button in cardImageButtons) {
-                if (e.Code == button.CardInfo.Code) {
+                if (e.Code == button.CardInfo.ImageId) {
                     button.IsToggled = e.IsVisible;
                 }
             }

--- a/ArkhamOverlay/Data/CardInfo.cs
+++ b/ArkhamOverlay/Data/CardInfo.cs
@@ -29,6 +29,7 @@ namespace ArkhamOverlay.Data {
             IsBonded = isBonded;
             if (cardBack) {
                 Name += " (Back)";
+                Code += "-Back";
             }
 
             //stometimes if we are closing, this will be null and we can just bail

--- a/ArkhamOverlay/Data/CardInfo.cs
+++ b/ArkhamOverlay/Data/CardInfo.cs
@@ -18,6 +18,7 @@ namespace ArkhamOverlay.Data {
 
         public CardInfo(ArkhamDbCard arkhamDbCard, int count, bool isPlayerCard, bool cardBack = false, bool isBonded = false) {
             Code = arkhamDbCard.Code;
+            ImageId = Code;
             Count = count;
             Name = arkhamDbCard.Xp == "0" || string.IsNullOrEmpty(arkhamDbCard.Xp) ? arkhamDbCard.Name : arkhamDbCard.Name + " (" + arkhamDbCard.Xp + ")";
             NameWithoutXp = arkhamDbCard.Name;
@@ -29,7 +30,7 @@ namespace ArkhamOverlay.Data {
             IsBonded = isBonded;
             if (cardBack) {
                 Name += " (Back)";
-                Code += "-Back";
+                ImageId += "-Back";
             }
 
             //stometimes if we are closing, this will be null and we can just bail
@@ -39,10 +40,12 @@ namespace ArkhamOverlay.Data {
         }
 
         public CardInfo(LocalManifestCard localCard, bool cardBack) {
-            Code = "";
+            Code = localCard.ArkhamDbId;
+            ImageId = Code;
             Count = 1;
             Name = localCard.Name;
             NameWithoutXp = localCard.Name;
+            
             Xp = 0;
             Faction = Faction.Other;
             Type = (CardType)Enum.Parse(typeof(CardType), localCard.CardType);
@@ -50,6 +53,7 @@ namespace ArkhamOverlay.Data {
             IsPlayerCard = false;
             if (cardBack) {
                 Name += " (Back)";
+                ImageId += "-Back";
             }
 
             //stometimes if we are closing, this will be null and we can just bail
@@ -62,6 +66,7 @@ namespace ArkhamOverlay.Data {
         public string NameWithoutXp { get; }
         public int Xp { get; }
         public string Code { get; }
+        public string ImageId { get; }
         public Faction Faction { get; set; }
         public int Count { get; set; }
         public string ImageSource { get; set; }

--- a/ArkhamOverlay/Data/CardZone.cs
+++ b/ArkhamOverlay/Data/CardZone.cs
@@ -70,7 +70,7 @@ namespace ArkhamOverlay.Data {
             var index = Buttons.IndexOf(button);
             var isImageAvailable = button?.CardInfo.ButtonImageAsBytes != null;
 
-            _eventBus.PublishButtonInfoChanged(CardGroupId, ButtonMode.Zone, index, button.Text, button.CardInfo.Code, button.IsToggled, isImageAvailable, action, button.Options);
+            _eventBus.PublishButtonInfoChanged(CardGroupId, ButtonMode.Zone, index, button.Text, button.CardInfo.ImageId, button.IsToggled, isImageAvailable, action, button.Options);
         }
 
         private void PublishButtonRemoved(int index) {

--- a/ArkhamOverlay/Data/CardZone.cs
+++ b/ArkhamOverlay/Data/CardZone.cs
@@ -70,7 +70,7 @@ namespace ArkhamOverlay.Data {
             var index = Buttons.IndexOf(button);
             var isImageAvailable = button?.CardInfo.ButtonImageAsBytes != null;
 
-            _eventBus.PublishButtonInfoChanged(CardGroupId, ButtonMode.Zone, index, button.Text, button.IsToggled, isImageAvailable, action, button.Options);
+            _eventBus.PublishButtonInfoChanged(CardGroupId, ButtonMode.Zone, index, button.Text, button.CardInfo.Code, button.IsToggled, isImageAvailable, action, button.Options);
         }
 
         private void PublishButtonRemoved(int index) {

--- a/ArkhamOverlay/Data/Player.cs
+++ b/ArkhamOverlay/Data/Player.cs
@@ -60,7 +60,7 @@ namespace ArkhamOverlay.Data {
 
         public string Name { get { return CardGroup.Name; } }
 
-        string IHasImageButton.Code { get { return Name; } }
+        string IHasImageButton.ImageId { get { return Name; } }
 
         CardType IHasImageButton.ImageCardType { get { return CardType.Investigator; } }
 

--- a/ArkhamOverlay/Data/Player.cs
+++ b/ArkhamOverlay/Data/Player.cs
@@ -60,6 +60,8 @@ namespace ArkhamOverlay.Data {
 
         public string Name { get { return CardGroup.Name; } }
 
+        string IHasImageButton.Code { get { return Name; } }
+
         CardType IHasImageButton.ImageCardType { get { return CardType.Investigator; } }
 
         public string ImageSource { get; set; }

--- a/ArkhamOverlay/Pages/Overlay/OverlayController.cs
+++ b/ArkhamOverlay/Pages/Overlay/OverlayController.cs
@@ -383,7 +383,7 @@ namespace ArkhamOverlay.Pages.Overlay {
                 overlayCards.RemoveOverlayCards(overlayCard);
             }
 
-            _eventBus.PublishCardInfoVisibilityChanged(overlayCard.CardInfo.Name, false);
+            _eventBus.PublishCardInfoVisibilityChanged(overlayCard.CardInfo.Code, false);
         }
 
         private void ShowCardInfo(CardInfo cardInfo) {
@@ -399,7 +399,7 @@ namespace ArkhamOverlay.Pages.Overlay {
                 overlayCards[overlayCards.IndexOf(overlayCardToReplace)] = newOverlayCard;
             }
 
-            _eventBus.PublishCardInfoVisibilityChanged(cardInfo.Name, true); 
+            _eventBus.PublishCardInfoVisibilityChanged(cardInfo.Code, true); 
         }
         #endregion
 

--- a/ArkhamOverlay/Pages/Overlay/OverlayController.cs
+++ b/ArkhamOverlay/Pages/Overlay/OverlayController.cs
@@ -383,7 +383,7 @@ namespace ArkhamOverlay.Pages.Overlay {
                 overlayCards.RemoveOverlayCards(overlayCard);
             }
 
-            _eventBus.PublishCardInfoVisibilityChanged(overlayCard.CardInfo.Code, false);
+            _eventBus.PublishCardInfoVisibilityChanged(overlayCard.CardInfo.ImageId, false);
         }
 
         private void ShowCardInfo(CardInfo cardInfo) {
@@ -395,11 +395,11 @@ namespace ArkhamOverlay.Pages.Overlay {
             if (overlayCardToReplace == null) {
                 overlayCards.AddOverlayCard(newOverlayCard);
             } else {
-                _eventBus.PublishCardInfoVisibilityChanged(overlayCardToReplace.CardInfo.Name, false);
+                _eventBus.PublishCardInfoVisibilityChanged(overlayCardToReplace.CardInfo.ImageId, false);
                 overlayCards[overlayCards.IndexOf(overlayCardToReplace)] = newOverlayCard;
             }
 
-            _eventBus.PublishCardInfoVisibilityChanged(cardInfo.Code, true); 
+            _eventBus.PublishCardInfoVisibilityChanged(cardInfo.ImageId, true); 
         }
         #endregion
 

--- a/ArkhamOverlay/Services/CardImageService.cs
+++ b/ArkhamOverlay/Services/CardImageService.cs
@@ -34,9 +34,9 @@ namespace ArkhamOverlay.Services {
             try {
                 _logger.LogMessage($"Loading image for button {hasImageButton.Name}");
 
-                if (_cache.IsInCache(hasImageButton.Name)) {
+                if (_cache.IsInCache(hasImageButton.Code)) {
                     _logger.LogMessage($"Found image in cache for button {hasImageButton.Name}");
-                    hasImageButton.Image = _cache.GetFromCache(hasImageButton.Name);
+                    hasImageButton.Image = _cache.GetFromCache(hasImageButton.Code);
                     if (hasImageButton.Image is BitmapImage bitmapImage && bitmapImage.IsDownloading) {
                         bitmapImage.DownloadCompleted += (s, e) => {
                             CropImage(hasImageButton);
@@ -51,11 +51,11 @@ namespace ArkhamOverlay.Services {
                 if (uri.IsFile) {
                     var localImage = ImageUtils.LoadLocalImage(uri);
                     hasImageButton.Image = localImage;
-                    _cache.SaveTocache(hasImageButton.Name, localImage);
+                    _cache.SaveTocache(hasImageButton.Code, localImage);
                     CropImage(hasImageButton);
                 } else {
                     var bitmapImage = new BitmapImage(uri);
-                    _cache.SaveTocache(hasImageButton.Name, bitmapImage);
+                    _cache.SaveTocache(hasImageButton.Code, bitmapImage);
                     bitmapImage.DownloadCompleted += (s, e) => {
                         CropImage(hasImageButton);
                     };

--- a/ArkhamOverlay/Services/CardImageService.cs
+++ b/ArkhamOverlay/Services/CardImageService.cs
@@ -34,9 +34,9 @@ namespace ArkhamOverlay.Services {
             try {
                 _logger.LogMessage($"Loading image for button {hasImageButton.Name}");
 
-                if (_cache.IsInCache(hasImageButton.Code)) {
+                if (_cache.IsInCache(hasImageButton.ImageId)) {
                     _logger.LogMessage($"Found image in cache for button {hasImageButton.Name}");
-                    hasImageButton.Image = _cache.GetFromCache(hasImageButton.Code);
+                    hasImageButton.Image = _cache.GetFromCache(hasImageButton.ImageId);
                     if (hasImageButton.Image is BitmapImage bitmapImage && bitmapImage.IsDownloading) {
                         bitmapImage.DownloadCompleted += (s, e) => {
                             CropImage(hasImageButton);
@@ -51,11 +51,11 @@ namespace ArkhamOverlay.Services {
                 if (uri.IsFile) {
                     var localImage = ImageUtils.LoadLocalImage(uri);
                     hasImageButton.Image = localImage;
-                    _cache.SaveTocache(hasImageButton.Code, localImage);
+                    _cache.SaveTocache(hasImageButton.ImageId, localImage);
                     CropImage(hasImageButton);
                 } else {
                     var bitmapImage = new BitmapImage(uri);
-                    _cache.SaveTocache(hasImageButton.Code, bitmapImage);
+                    _cache.SaveTocache(hasImageButton.ImageId, bitmapImage);
                     bitmapImage.DownloadCompleted += (s, e) => {
                         CropImage(hasImageButton);
                     };

--- a/ArkhamOverlay/Services/CardLoadService.cs
+++ b/ArkhamOverlay/Services/CardLoadService.cs
@@ -275,7 +275,7 @@ namespace ArkhamOverlay.Services {
                 }
             }
 
-            var localCards = _localCardsService.LoadLocalCardsFromPacks(_appData.Game.LocalPacks);
+            var allLocalCards = _localCardsService.LoadLocalCards();
 
             var cards = new List<CardInfo>();
             foreach (var pack in packsToLoad) {
@@ -287,7 +287,7 @@ namespace ArkhamOverlay.Services {
                     }
 
                     // Look for corresponding local card and grab its image. Remove it from the list to avoid duplicates
-                    FindCardImageSource(arkhamDbCard, localCards, removeLocalCard: true);
+                    FindCardImageSource(arkhamDbCard, allLocalCards, removeLocalCard: true);
 
                     var newCard = new CardInfo(arkhamDbCard, 1, isPlayerCard: false);
                     _cardImageService.LoadImage(newCard);
@@ -302,6 +302,7 @@ namespace ArkhamOverlay.Services {
                 }
             }
 
+            var localCards = _localCardsService.LoadLocalCardsFromPacks(_appData.Game.LocalPacks);
             foreach (var localCard in localCards) {
                 var newLocalCard = new CardInfo(localCard, false);
                 _cardImageService.LoadImage(newLocalCard);

--- a/ArkhamOverlay/Services/TcpRequestHandler.cs
+++ b/ArkhamOverlay/Services/TcpRequestHandler.cs
@@ -74,17 +74,17 @@ namespace ArkhamOverlay.Services {
 
             var cardGroup = _appData.Game.GetCardGroup(buttonImageRequest.CardGroupId);
             byte[] imageAsBytes = null;
-            var name = string.Empty;
+            var code = string.Empty;
             if (!buttonImageRequest.ButtonMode.HasValue || !buttonImageRequest.Index.HasValue) {
                 SendButtonImageResponse(request.Socket, cardGroup.Name, cardGroup.ButtonImageAsBytes);
             } else {
                 if (cardGroup.GetButton(buttonImageRequest.ButtonMode.Value, buttonImageRequest.Index.Value) is CardInfoButton cardButton) {
-                    name = cardButton.CardInfo.Name;
+                    code = cardButton.CardInfo.Code;
                     imageAsBytes = cardButton.CardInfo.ButtonImageAsBytes;
                 }
             }
 
-            SendButtonImageResponse(request.Socket, name, imageAsBytes);
+            SendButtonImageResponse(request.Socket, code, imageAsBytes);
         }
 
         private void HandleRequestStatValue(TcpRequest request) {
@@ -166,6 +166,7 @@ namespace ArkhamOverlay.Services {
                     CardButtonType = GetCardType(cardImageButton?.CardInfo),
                     Name = cardButton.Text.Replace("Right Click", "Long Press"),
                     IsToggled = cardButton.IsToggled,
+                    Code = cardImageButton?.CardInfo.Code,
                     ImageAvailable = cardImageButton?.CardInfo.ButtonImageAsBytes != null,
                     ButtonOptions = cardButton.Options
                 };
@@ -173,9 +174,9 @@ namespace ArkhamOverlay.Services {
             Send(socket, cardInfoReponse.ToString());
         }
 
-        private void SendButtonImageResponse(Socket socket, string name, byte[] imageAsBytes) {
+        private void SendButtonImageResponse(Socket socket, string code, byte[] imageAsBytes) {
             var buttonImageResponse = new ButtonImageResponse { 
-                Name = name, 
+                Code = code, 
                 Bytes = imageAsBytes
             };
 

--- a/ArkhamOverlay/Services/TcpRequestHandler.cs
+++ b/ArkhamOverlay/Services/TcpRequestHandler.cs
@@ -74,17 +74,17 @@ namespace ArkhamOverlay.Services {
 
             var cardGroup = _appData.Game.GetCardGroup(buttonImageRequest.CardGroupId);
             byte[] imageAsBytes = null;
-            var code = string.Empty;
+            var imageId = string.Empty;
             if (!buttonImageRequest.ButtonMode.HasValue || !buttonImageRequest.Index.HasValue) {
                 SendButtonImageResponse(request.Socket, cardGroup.Name, cardGroup.ButtonImageAsBytes);
             } else {
                 if (cardGroup.GetButton(buttonImageRequest.ButtonMode.Value, buttonImageRequest.Index.Value) is CardInfoButton cardButton) {
-                    code = cardButton.CardInfo.Code;
+                    imageId = cardButton.CardInfo.ImageId;
                     imageAsBytes = cardButton.CardInfo.ButtonImageAsBytes;
                 }
             }
 
-            SendButtonImageResponse(request.Socket, code, imageAsBytes);
+            SendButtonImageResponse(request.Socket, imageId, imageAsBytes);
         }
 
         private void HandleRequestStatValue(TcpRequest request) {
@@ -166,7 +166,7 @@ namespace ArkhamOverlay.Services {
                     CardButtonType = GetCardType(cardImageButton?.CardInfo),
                     Name = cardButton.Text.Replace("Right Click", "Long Press"),
                     IsToggled = cardButton.IsToggled,
-                    Code = cardImageButton?.CardInfo.Code,
+                    Code = cardImageButton?.CardInfo.ImageId,
                     ImageAvailable = cardImageButton?.CardInfo.ButtonImageAsBytes != null,
                     ButtonOptions = cardButton.Options
                 };

--- a/StreamDeckPlugin/Services/DynamicActionInfo.cs
+++ b/StreamDeckPlugin/Services/DynamicActionInfo.cs
@@ -36,7 +36,7 @@ namespace StreamDeckPlugin.Services {
         static internal bool CardInfoHasChanged(this IDynamicActionInfo dynamicActionInfo, ICardInfo cardInfo) {
             return dynamicActionInfo.Text != cardInfo.Name
                 || dynamicActionInfo.IsToggled != cardInfo.IsToggled
-                || dynamicActionInfo.ImageId != cardInfo.Name
+                || dynamicActionInfo.ImageId != cardInfo.Code
                 || dynamicActionInfo.IsImageAvailable != cardInfo.ImageAvailable
                 || dynamicActionInfo.ButtonOptions.SequenceEqual(cardInfo.ButtonOptions);
         }
@@ -44,7 +44,7 @@ namespace StreamDeckPlugin.Services {
         static internal void UpdateFromCardInfo(this IDynamicActionInfo dynamicActionInfo, ICardInfo cardInfo) {
             dynamicActionInfo.Text = cardInfo.Name.Replace("Right Click", "Long Press");
             dynamicActionInfo.IsToggled = cardInfo.IsToggled;
-            dynamicActionInfo.ImageId = cardInfo.Name;
+            dynamicActionInfo.ImageId = cardInfo.Code;
             dynamicActionInfo.IsImageAvailable = cardInfo.ImageAvailable;
             dynamicActionInfo.ButtonOptions = cardInfo.ButtonOptions;
         }

--- a/StreamDeckPlugin/Services/DynamicActionInfoStore.cs
+++ b/StreamDeckPlugin/Services/DynamicActionInfoStore.cs
@@ -24,7 +24,7 @@ namespace StreamDeckPlugin.Services {
             _imageService = imageService;
 
             eventBus.SubscribeToImageLoadedEvent(e => ImageLoaded(e.ImageId));
-            eventBus.SubscribeToCardInfoVisibilityChanged(e => CardInfoVisibilityChanged(e.Name, e.IsVisible));
+            eventBus.SubscribeToCardInfoVisibilityChanged(e => CardInfoVisibilityChanged(e.Code, e.IsVisible));
             eventBus.SubscribeToButtonInfoChanged(ButtonInfoChanged);
             eventBus.SubscribeToButtonRemoved(ButtonRemoved);
             eventBus.SubscribeToButtonTextChanged(ButtonTextChanged);
@@ -90,11 +90,11 @@ namespace StreamDeckPlugin.Services {
             PublishChangeEventsForChangedActions(dynamicActionInfoWithImageItems);
         }
 
-        private void CardInfoVisibilityChanged(string name, bool isVisible) {
+        private void CardInfoVisibilityChanged(string code, bool isVisible) {
             var changedActionInfoList = new List<DynamicActionInfo>();
             lock (_cacheLock) {
                 foreach (var dynamicActionInfo in _dynamicActionInfoList) {
-                    if (dynamicActionInfo.ImageId == name && dynamicActionInfo.IsToggled != isVisible) {
+                    if (dynamicActionInfo.ImageId == code && dynamicActionInfo.IsToggled != isVisible) {
                         dynamicActionInfo.IsToggled = isVisible;
                         changedActionInfoList.Add(dynamicActionInfo);
                     }

--- a/StreamDeckPlugin/Services/ImageService.cs
+++ b/StreamDeckPlugin/Services/ImageService.cs
@@ -12,7 +12,7 @@ namespace StreamDeckPlugin.Services {
         string GetImage(string imageId);
         string GetImage(IDynamicActionInfo dynamicActionInfo);
         bool HasImage(string imageId);
-        void UpdateButtonImage(string name, byte[] bytes);
+        void UpdateButtonImage(string imageId, byte[] bytes);
 
         /// <summary>
         /// Check to see if this image is stored- if it is not, retrieve it

--- a/StreamDeckPlugin/Services/SendEventHandler.cs
+++ b/StreamDeckPlugin/Services/SendEventHandler.cs
@@ -74,7 +74,7 @@ namespace StreamDeckPlugin.Services {
 
             var response = SendRequest<ButtonImageResponse>(request);
             if (response != null) {
-                _imageService.UpdateButtonImage(response.Name, response.Bytes);
+                _imageService.UpdateButtonImage(response.Code, response.Bytes);
             }
         }
 


### PR DESCRIPTION
Had multiple issues where the app was getting confused with Cards that had the same name- the Return to Boundary Beyond showed me this. I fixed this (along with one issue along the way where it wasn't resolving local images for encounter cards).