### PR TITLE
Fixed issue with loading cards from local db not having a code

### DIFF
--- a/ArkhamOverlay/Data/CardInfo.cs
+++ b/ArkhamOverlay/Data/CardInfo.cs
@@ -3,6 +3,7 @@ using ArkhamOverlay.Common.Enums;
 using ArkhamOverlay.Services;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Windows;
 using System.Windows.Media;
 
@@ -40,7 +41,7 @@ namespace ArkhamOverlay.Data {
         }
 
         public CardInfo(LocalManifestCard localCard, bool cardBack) {
-            Code = localCard.ArkhamDbId;
+            Code = string.IsNullOrEmpty(localCard.ArkhamDbId) ? Path.GetFileName(localCard.FilePath) : localCard.ArkhamDbId;
             ImageId = Code;
             Count = 1;
             Name = localCard.Name;


### PR DESCRIPTION
The issue here is when local cards have no arkhamDBID yet (because they are cards not yet in ArkhamDB) they are causing problems, as the code is ultimately used for storing images in the local cache. When that happens, this will use the card name instead.